### PR TITLE
Support externally declared relation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ order to conveniently generate characters and backstories for creative purposes.
                                            VillainHome) is Result))))
 
 ;; we generate lots of story strings; we query the first such string below
-(define solution-stream (all story-program))
+(define solution-stream (solve story-program))
 
 > (get (stream-first solution-stream) 'story)
 "The heroic TA Zack from CT worked with Ari to thwart the wicked prof Ben of NY"

--- a/private/compile.rkt
+++ b/private/compile.rkt
@@ -69,21 +69,34 @@
                           (rt:fact add1 (list (rt:variable 'X)) 2))))
      '()))
 
+;; An CompilerState is a
+;; (compiler-state MutSymbolTable MutSymbolSet MutSymbolSet),
+;; tracking 
+(struct compiler-state [arities imports externs])
+
 ;; this is the old compile-time function
-;; ImportsSyntax LogicSyntax -> RacketSyntax
-(define (compile-logic imports-stx logic-stx)
-  (define rel-arities (local-symbol-table))
-  (define imported-rel-vars (mutable-set))
+;; ImportsSyntax IdsSyntax LogicSyntax -> RacketSyntax
+(define (compile-logic imports-stx externs-stx logic-stx)
+  (define arities (local-symbol-table))
+  (define imports (local-symbol-set))
   ; add all imported symbols; later we use this to compile attibutes
   (for ([stx-pair (syntax->list imports-stx)])
     (syntax-parse stx-pair
       [[rel-id _]
        ; we want to put the symbols in our symbol table, not the identifiers,
        ; otherwise we will not have the right notion of element equality
-       (set-add! imported-rel-vars (syntax->datum #'rel-id))]))
+       (symbol-set-add! imports #'rel-id)]))
+
+  (define ext-rel-vars (local-symbol-set))
+  #;(apply immutable-symbol-set (syntax->list externs-stx))
+  ; similarly, add in the external variables
+  (for ([ex-id (syntax->list externs-stx)])
+    (symbol-set-add! ext-rel-vars ex-id))
+
+  (define state (compiler-state arities imports ext-rel-vars))
 
   (define body
-    (let ([compile-decl ((curry compile-decl) rel-arities imported-rel-vars)]
+    (let ([compile-decl ((curry compile-decl) state)]
           [logic-stx (flatten-decls logic-stx)])
       (syntax-parse logic-stx
         [(d ...)
@@ -128,36 +141,36 @@
     [[_ ((_ is? {_ ...+}) :- _ ...+)] #t]
     [_ #f]))
 
-;; MutSymbolTable MutSymbolSet DeclSyntax -> [ListOf RacketSyntax]
+;; CompilerState DeclSyntax -> [ListOf RacketSyntax]
 ;; This returns a list so that we can expand to multiple decls in the case of
 ;; a `decls` block.
 ;; Note that DeclSyntax _does_ include the expanded relation occurrence
-(define (compile-decl arities imports decl-stx)
+(define (compile-decl state decl-stx)
   ; partial application to thread around references to the symbol tables
-  (let ([compile-conc ((curry compile-conc) arities imports)]
-        [compile-decl ((curry compile-decl) arities imports)])
+  (let ([compile-conc ((curry compile-conc) state)]
+        [compile-decl ((curry compile-decl) state)])
     (syntax-parse decl-stx
       #:datum-literals (decls :-)
       [(decls d ...) (flatten (map compile-decl (attribute d)))]
       ;; get rid of the outer ref
       [[_ (conc :- prems ...+)]
        #:with (prem ...)
-       (map ((curry compile-prem) arities imports) (attribute prems))
+       (map ((curry compile-prem) state) (attribute prems))
        (list #`(rt:rule #,(compile-conc #'conc) (list prem ...)))]
       [[_ conc]
        (list #`(rt:rule #,(compile-conc #'conc) '()))])))
 
-;; MutSymbolTable MutSymbolSet ConclusionSyntax -> RacketSyntax
+;; CompilerState ConclusionSyntax -> RacketSyntax
 ;; throws a compile-time error when there is a binding
 ;; occurrence of a variable in the conclusion, which is disallowed
-(define (compile-conc arities imports conc-stx)
+(define (compile-conc state conc-stx)
   ;; shadowing to disallow compiling terms with binding occurrences
   (let ([compile-term ((curry compile-term)
                        #:forbid-binds "cannot bind variables in conclusions")]
-        [compile-rel-id ((curry compile-rel-id) arities imports)]
+        [compile-rel-id ((curry compile-rel-id) state)]
         [raise-if-imported!
          (lambda (name)
-           (when (set-member? imports (syntax->datum name))
+           (when (symbol-set-member? (compiler-state-imports state) name)
              (raise-syntax-error
               #f
               "imported relations cannot appear in conclusions"
@@ -180,26 +193,26 @@
        (raise-if-imported! #'name)
        #'(rt:rule-frag rel-var-comped (list comp-t ...) '() #f)])))
 
-;; MutSymbolTable MutSymbolSet PremiseSyntax -> RacketSyntax
-(define (compile-prem arities imports prem-stx)
-  (let ([compile-rel-id ((curry compile-rel-id) arities imports)]
+;; CompilerState PremiseSyntax -> RacketSyntax
+(define (compile-prem state prem-stx)
+  (let ([compile-rel-id ((curry compile-rel-id) state)]
         [compile-term-named
          (lambda (name)
            (curry compile-term
                   #:forbid-binds
-                  (and (set-member? imports name)
+                  (and (symbol-set-member? (compiler-state-imports state) name)
                        "cannot run imported relations backwards")))])
     (syntax-parse prem-stx
       #:datum-literals (is)
       [((name t ...) is ch)
        #:with (comp-t ...)
-       (map (compile-term-named (syntax->datum #'name)) (attribute t))
+       (map (compile-term-named #'name) (attribute t))
        #:with rel-var-comped (compile-rel-id #'name (length (attribute t)))
        #`(rt:fact rel-var-comped (list comp-t ...) #,(compile-term #'ch))]
       [(name t ...)
        #:with (comp-t ...) (map compile-term (attribute t))
        #:with rel-var-comped (compile-rel-id #'name (length (attribute t)))
-       (when (set-member? imports (syntax->datum #'name))
+       (when (symbol-set-member? (compiler-state-imports state) #'name)
          (raise-syntax-error #f
                              "imported relations must be used with 'is'"
                              #'name))
@@ -209,7 +222,7 @@
 ;; compiles to a reference to a bound procedure if it was imported;
 ;; otherwise checks the arity (if seen before, or sets arity otherwise)
 ;; and returns as the runtime representation of the name
-(define (compile-rel-id arities imports rel-id arity)
+(define (compile-rel-id state rel-id arity)
   (define rel-sym (syntax->datum rel-id))
 
   (when (member rel-sym RESERVED-NAMES)
@@ -222,12 +235,16 @@
         (symbol-table-ref table key)
         (begin (symbol-table-set! table key val #:allow-overwrite? #t)
                val)))
-  
-  (if (set-member? imports rel-sym)
-      ; sets to arity if missing from the table -> will be equal
-      rel-id
-      (let ([expected-arity (symbol-table-ref! arities rel-id arity)])
-        (unless (= arity expected-arity)
+
+  (cond [(symbol-set-member? (compiler-state-imports state) rel-id)
+         rel-id]
+        [(symbol-set-member? (compiler-state-externs state) rel-id)
+         #`'#,rel-id]
+        [else
+         (define expected-arity
+           ; will add to the table if missing, which will pass equality check
+           (symbol-table-ref! (compiler-state-arities state) rel-id arity))
+         (unless (= arity expected-arity)
           (raise-syntax-error
            #f
            (format
@@ -236,7 +253,7 @@
             expected-arity
             arity)
            rel-id))
-        #`#'#,rel-id)))
+         #`#'#,rel-id]))
 
 ;; TermSyntax -> RacketSyntax
 (define (compile-term term-stx #:forbid-binds [message #f])

--- a/private/database.rkt
+++ b/private/database.rkt
@@ -43,8 +43,7 @@
             (for/set ([c (database-constraints db)]
                       #:when
                       (not (and (equal? (fact-terms f) (constraint-terms c))
-                                (bound-identifier=? (fact-rel f)
-                                                    (constraint-rel c)))))
+                                (rel=? (fact-rel f) (constraint-rel c)))))
               c)))
 
 ;; db-add-constraint : Constraint Database -> Database
@@ -74,7 +73,7 @@
   ;; Determine if the given fact has the same attribute as
   ;; rel and terms.
   (define (attr-like? f)
-    (and (bound-identifier=? (fact-rel f) rel)
+    (and (rel=? (fact-rel f) rel)
          (equal? (fact-terms f) terms)))
   (not (db-empty? (db-filter attr-like? db))))
 
@@ -102,14 +101,14 @@
   ;; different values.
   ;; This should only be called when to-add is a Fact.
   (define (fact-consistent? known)
-    (not (and (bound-identifier=? (fact-rel to-add) (fact-rel known))
+    (not (and (rel=? (fact-rel to-add) (fact-rel known))
               (equal? (fact-terms to-add) (fact-terms known))
               (not (equal? (fact-value to-add) (fact-value known))))))
 
   ;; constraint-valid? : Constraint Fact -> Boolean
   ;; Determine if the fact is consistent given the constraint c.
   (define (constraint-valid? c f)
-    (not (and (bound-identifier=? (fact-rel f) (constraint-rel c))
+    (not (and (rel=? (fact-rel f) (constraint-rel c))
               (equal? (fact-terms f) (constraint-terms c))
               (set-member? (constraint-none-of c) (fact-value f)))))
 

--- a/private/database.rkt
+++ b/private/database.rkt
@@ -18,6 +18,10 @@
 (define (db-of . facts)
   (database (apply set facts) (set)))
 
+;; factset->db: [SetOf Fact] -> Database
+(define (factset->db factset)
+  (database factset (set)))
+
 ;; db-empty? : Database -> Boolean
 ;; Returns #f if the database contains facts.
 (define (db-empty? db)

--- a/private/runtime.rkt
+++ b/private/runtime.rkt
@@ -214,7 +214,7 @@
 
     ; 'tried = #t for our purposes
     (define (conclusion=? a b)
-      (and (bound-identifier=? (rule-frag-name a) (rule-frag-name b))
+      (and (rel=? (rule-frag-name a) (rule-frag-name b))
            (equal? (rule-frag-terms a) (rule-frag-terms b))
            (equal? (rule-frag-choices a) (rule-frag-choices b))
            (equal? (not (rule-frag-is?? a)) (not (rule-frag-is?? b)))))
@@ -299,7 +299,7 @@
 
   ;; looks-like? : Fact -> Boolean
   (define (looks-like? fact)
-    (and (bound-identifier=? (fact-rel open) (fact-rel fact))
+    (and (rel=? (fact-rel open) (fact-rel fact))
          (andmap similar?
                  (fact-terms open)
                  (fact-terms fact))
@@ -409,7 +409,7 @@
   (and (or (eq? (fact-rel f) rel)  ; for proc + symbols
            (and (syntax? (fact-rel f))
                 (syntax? rel)
-                (bound-identifier=? (fact-rel f) rel)))
+                (rel=? (fact-rel f) rel)))
        (equal? (fact-terms f) terms)))
 
 ;; has: Solution Symbol Datum ... -> Bool

--- a/private/spec.rkt
+++ b/private/spec.rkt
@@ -18,11 +18,11 @@
  (binding-class rel-var)
  (extension-class logic-macro #:binding-space minidusa)
 
- ;; (logic/importing <imps> <decl> ...)
+ ;; (logic/importing <imps> (<id> ...) <decl> ...)
  (host-interface/expression
-  (logic/importing i:imps d:decl ...)
-  #:binding (nest i (scope (import d) ...))
-  (compile-logic #'i #'(d ...)))
+  (logic/importing i:imps (ex:rel-var ...) d:decl ...)
+  #:binding (nest i (scope (bind ex) ... (import d) ...))
+  (compile-logic #'i #'(ex ...) #'(d ...)))
 
  ;; <imps> ::= (<imp> ...)
  ;; <imp>  ::= x:racket-var
@@ -126,12 +126,16 @@
  )
 
 ;; logic : (logic <decl> ...)
-;;       | (logic #:import [<imp> ...] <decl> ...)
+;;       | (logic #:import [<imp> ...] #:extern [id ...] <decl> ...)
 (define-syntax logic
   (lambda (stx)
     (syntax-parse stx
       [(_ (~or* (~seq #:import imports)
                 (~seq))
+          ;; TODO: is there a way to make it so order doesn't matter?
+          (~or* (~seq #:extern externs)
+                (~seq))
           ds ...)
        #:with imps (or (attribute imports) #'())
-       #'(logic/importing imps ds ...)])))
+       #:with exts (or (attribute externs) #'())
+       #'(logic/importing imps exts ds ...)])))

--- a/scribblings/minidusa.scrbl
+++ b/scribblings/minidusa.scrbl
@@ -175,7 +175,7 @@ characters and backstories for creative purposes.
                                                      " of "
                                                      VillainHome) is Result))))
 
-          (define solution-stream (all story-program))
+          (define solution-stream (solve story-program))
           
           (get (stream-first solution-stream) 'story)]
 
@@ -247,7 +247,8 @@ supported.
  Determines whether the argument is @code{NONE}.
 }
 
-@defproc[(all [program program?]) (stream? solution?)]{
+@; TODO: this actually takes in an optional keyword argument too, and is a macro
+@defproc[(solve [program program?]) (stream? solution?)]{
  Obtain a stream of all possible solutions of the given program
  that is defined via a @code{logic} macro. The stream may be infinite,
  and computing the next item may not always terminate.

--- a/testing.rkt
+++ b/testing.rkt
@@ -29,5 +29,5 @@
 
 ;; check-all-solutions: Program [ListOf [SetOf Fact]] -> Void
 (define-syntax-rule (check-all-solutions prog expected)
-  (check-equal? (map soln->factset (stream->list (all prog)))
+  (check-equal? (map soln->factset (stream->list (solve prog)))
                 expected))

--- a/tests/extensions.rkt
+++ b/tests/extensions.rkt
@@ -116,17 +116,25 @@
           (fact 'ok '() #t)
           (fact 'd '() #t))))
 
-  (define-dsl-syntax mydecl logic-macro
+  (define-dsl-syntax deduce-name logic-macro
     (lambda (stx)
       (syntax-parse stx
         [(_ name)
          #'(decls (foo)
                   ((name) :- (foo)))])))
 
+  (define-dsl-syntax has-foo-1 logic-macro
+    (lambda (stx)
+      (syntax-parse stx
+        [(_)
+         #'(foo 1)])))
+
   (check-all-solutions
    (logic
-     (mydecl bar)
      ;; tests that the arities do not conflict, that the fresh symbol foo does
      ;; not appear in the solution, but bar (deduced using foo) DOES appear
+     (deduce-name bar)
+     ;; this will again test arity, and that foo 2 is not deduced
+     (has-foo-1)
      ((foo 2) :- (foo 1)))
    (list (set (fact 'bar '())))))

--- a/tests/extensions.rkt
+++ b/tests/extensions.rkt
@@ -6,20 +6,20 @@
            syntax-spec-v3)
 
   (check-equal?
-   (length (stream->list (all (logic
-                                (edge 'a 'b)
-                                (edge 'b 'c)
-                                (edge 'a 'c)
-                                (edge 'c 'd)
-                                (edge 'a 'e)
-                                ((edge X Y) :- (edge Y X))
-                                ((node X) :- (edge X _))
-                                (((color X) is {1 2 3}) :- (node X))
+   (length (stream->list (solve (logic
+                                  (edge 'a 'b)
+                                  (edge 'b 'c)
+                                  (edge 'a 'c)
+                                  (edge 'c 'd)
+                                  (edge 'a 'e)
+                                  ((edge X Y) :- (edge Y X))
+                                  ((node X) :- (edge X _))
+                                  (((color X) is {1 2 3}) :- (node X))
 
-                                ((ok) is {#t})
-                                (((ok) is {#f}) :- (edge X Y)
-                                                ((color X) is C)
-                                                ((color Y) is C))))))
+                                  ((ok) is {#t})
+                                  (((ok) is {#f}) :- (edge X Y)
+                                                  ((color X) is C)
+                                                  ((color Y) is C))))))
    24)
 
   (define-dsl-syntax graph logic-macro
@@ -49,17 +49,17 @@
            ((edge X Y) :- (edge Y X)))
 
   (check-equal?
-   (length (stream->list (all (logic
-                                (graph edge
-                                       ('a ['b 'c 'e])
-                                       ('c ['b 'd]))
-                                ((node X) :- (edge X _))
-                                (((color X) is {1 2 3}) :- (node X))
+   (length (stream->list (solve (logic
+                                  (graph edge
+                                         ('a ['b 'c 'e])
+                                         ('c ['b 'd]))
+                                  ((node X) :- (edge X _))
+                                  (((color X) is {1 2 3}) :- (node X))
 
-                                ((ok) is {#t})
-                                (((ok) is {#f}) :- (edge X Y)
-                                                ((color X) is C)
-                                                ((color Y) is C))))))
+                                  ((ok) is {#t})
+                                  (((ok) is {#f}) :- (edge X Y)
+                                                  ((color X) is C)
+                                                  ((color Y) is C))))))
    24)
 
   (define-dsl-syntax forbid logic-macro
@@ -70,17 +70,17 @@
                   (((name) is {#f}) :- p ...))])))
 
   (check-equal?
-   (length (stream->list (all (logic
-                                (graph edge
-                                       ('a ['b 'c 'e])
-                                       ('c ['b 'd]))
-                                ((node X) :- (edge X _))
-                                (((color X) is {1 2 3}) :- (node X))
+   (length (stream->list (solve (logic
+                                  (graph edge
+                                         ('a ['b 'c 'e])
+                                         ('c ['b 'd]))
+                                  ((node X) :- (edge X _))
+                                  (((color X) is {1 2 3}) :- (node X))
 
-                                (forbid ok
-                                        (edge X Y)
-                                        ((color X) is C)
-                                        ((color Y) is C))))))
+                                  (forbid ok
+                                          (edge X Y)
+                                          ((color X) is C)
+                                          ((color Y) is C))))))
    24)
 
   (check-all-solutions

--- a/tests/runtime.rkt
+++ b/tests/runtime.rkt
@@ -9,41 +9,42 @@
      '()))
 
   (check-equal?
-   (has (stream-first (all simple-program)) 'foo 1)
+   (has (stream-first (solve simple-program)) 'foo 1)
    #t)
   
   (check-equal?
-   (has (stream-first (all simple-program)) 'foo 2)
+   (has (stream-first (solve simple-program)) 'foo 2)
    #f)
 
   (check-equal?
-   (get (stream-first (all simple-program)) 'foo 1)
+   (get (stream-first (solve simple-program)) 'foo 1)
    'a)
 
   (check-exn
    ;; TODO: make this error message better
    #rx""
-   (lambda () (get (stream-first (all simple-program)) 'foo 2)))
+   (lambda () (get (stream-first (solve simple-program)) 'foo 2)))
   
   ;; we can run imported relations
   (check-equal?
-   (stream->list (all (program
-                       (list (rule (rule-frag 'foo '() '() #f)
-                                   (list (fact add1 '(0) 1))))
-                       '())))
+   (stream->list (solve (program
+                         (list (rule (rule-frag 'foo '() '() #f)
+                                     (list (fact add1 '(0) 1))))
+                         '())))
    (list (solution (db-of (make-fact 'foo '())))))
 
   (check-equal?
-   (stream->list (all (program
-                       (list (rule (rule-frag 'foo '() '() #f)
-                                   (list (fact * '(0 1 2) 1))))
-                       '())))
+   (stream->list (solve (program
+                         (list (rule (rule-frag 'foo '() '() #f)
+                                     (list (fact * '(0 1 2) 1))))
+                         '())))
    (list (solution (db-of))))
 
   ;; example where we bind a variable based on an import
   (check-equal?
-   (stream->list (all (program
-                       (list (rule (rule-frag 'foo '() (list (variable 'X)) #f)
-                                   (list (fact + '(1 2 3 4) (variable 'X)))))
-                       '())))
+   (stream->list
+    (solve (program
+            (list (rule (rule-frag 'foo '() (list (variable 'X)) #f)
+                        (list (fact + '(1 2 3 4) (variable 'X)))))
+            '())))
    (list (solution (db-of (make-fact 'foo '() 10))))))

--- a/tests/runtime.rkt
+++ b/tests/runtime.rkt
@@ -4,7 +4,9 @@
   (require "../testing.rkt")
 
   (define simple-program
-    (logic ((foo 1) is {'a})))
+    (program
+     (list (rule (rule-frag 'foo '(1) '(a) #f) '()))
+     '()))
 
   (check-equal?
    (has (stream-first (all simple-program)) 'foo 1)

--- a/tests/test.rkt
+++ b/tests/test.rkt
@@ -240,4 +240,12 @@
               (fact 'b '()))
          (set (fact 'a '() 2)
               (fact 'b '()))))
+
+  ;; TODO: make sure that this plays well with hygiene when possible
+  (check-all-solutions
+   (logic #:extern (foo bar)
+     (foo 1)
+     (bar 2))
+   (list (set (fact 'foo '(1))
+              (fact 'bar '(2)))))
   )


### PR DESCRIPTION
Adds support for declaring some relation names as `#:extern`, which allows them to be used unhygenically. This is added to allow starting with a set of known facts which come from Racket (i.e. the source of some other data) for increased dynamicism.

These `extern` symbols still interact with syntax-spec for scoping, but (like `import`ed symbols) do _not_ have arity checking. It would be possible to check that they are internally consistent with each other, but that would not get any safety benefit (since the fact set you start solving with could still have the wrong arities). This might be nice to fix but is not needed for a first pass (time is of the essence currently).